### PR TITLE
Change attacks to use damage and energy requirements from database

### DIFF
--- a/pokepocketsim/core/card.py
+++ b/pokepocketsim/core/card.py
@@ -26,14 +26,9 @@ def _parse_card_data(card_data: List[Dict[str, Dict[str, Any]]]) -> List[Dict[st
         if "weakness" in pokemon and pokemon["weakness"]:
             pokemon["weakness"] = getattr(EnergyType, pokemon["weakness"])
 
-        # Convert attacks from detailed objects to function references
+        # Deep copy attacks list to avoid shared references
         if "attacks" in pokemon:
-            def convert_attack(attack_info: Dict[str, Any]) -> Callable:
-                # Convert title to function name (e.g., "Psychic Sphere" -> "psychic_sphere")
-                func_name = attack_info["title"].lower().replace(" ", "_")
-                return getattr(Attack, func_name)
-            
-            pokemon["attacks"] = [convert_attack(attack) for attack in pokemon["attacks"]]
+            pokemon["attacks"] = [attack.copy() for attack in pokemon["attacks"]]
 
         # Convert ability from string to instance if present
         if "ability" in pokemon and pokemon["ability"]:
@@ -92,7 +87,7 @@ class Card:
         name: str,
         hp: int,
         energy_type: EnergyType,
-        attacks: List[Callable],
+        attacks: List[Dict[str, Any]],  # attack metadata dicts from JSON
         retreat_cost: int,
         ability: Optional[Any] = None,
         weakness: Optional[EnergyType] = None,
@@ -107,7 +102,12 @@ class Card:
         self.hp: int = hp
         self.energy_type: EnergyType = energy_type
         self.energies: Dict[str, int] = {}
-        self.attacks: List[Callable] = attacks
+        
+        # attacks is expected to be a list of attack metadata dicts
+        if attacks is None:
+            self.attacks: List[Dict[str, Any]] = []
+        else:
+            self.attacks = [attack.copy() for attack in attacks]
         self.retreat_cost: int = retreat_cost
         self.modifiers: List[Any] = []
         self.ability: Optional[Any] = ability
@@ -189,7 +189,13 @@ class Card:
         self.hp = evolved_card_info["hp"] - (self.max_hp - self.hp)
         self.max_hp = evolved_card_info["hp"]
         self.energy_type = evolved_card_info["energy_type"]
-        self.attacks = evolved_card_info["attacks"]
+        self.attacks = evolved_card_info.get("attacks", [])
+
+        try:
+            self.attacks = [a.copy() for a in evolved_card_info["attacks"]]
+        except Exception:
+            self.attacks = []
+
         self.retreat_cost = evolved_card_info["retreat_cost"]
         self.ability = evolved_card_info["ability"]
         self.weakness = evolved_card_info["weakness"]

--- a/pokepocketsim/core/card.py
+++ b/pokepocketsim/core/card.py
@@ -26,9 +26,14 @@ def _parse_card_data(card_data: List[Dict[str, Dict[str, Any]]]) -> List[Dict[st
         if "weakness" in pokemon and pokemon["weakness"]:
             pokemon["weakness"] = getattr(EnergyType, pokemon["weakness"])
 
-        # Convert attacks from string names to function references
+        # Convert attacks from detailed objects to function references
         if "attacks" in pokemon:
-            pokemon["attacks"] = [getattr(Attack, name) for name in pokemon["attacks"]]
+            def convert_attack(attack_info: Dict[str, Any]) -> Callable:
+                # Convert title to function name (e.g., "Psychic Sphere" -> "psychic_sphere")
+                func_name = attack_info["title"].lower().replace(" ", "_")
+                return getattr(Attack, func_name)
+            
+            pokemon["attacks"] = [convert_attack(attack) for attack in pokemon["attacks"]]
 
         # Convert ability from string to instance if present
         if "ability" in pokemon and pokemon["ability"]:

--- a/pokepocketsim/data/database.json
+++ b/pokepocketsim/data/database.json
@@ -8,7 +8,20 @@
             "hp": 150,
             "energy_type": "Psychic",
             "ability": null,
-            "attacks": ["psydrive", "psychic_sphere"],
+            "attacks": [
+                {
+                    "energy_required": ["Psychic", "Colorless"],
+                    "title": "Psychic Sphere",
+                    "fixed_damage": 50,
+                    "effect": null
+                },
+                {
+                    "energy_required": ["Psychic", "Psychic", "Colorless", "Colorless"],
+                    "title": "Psydrive",
+                    "fixed_damage": 150,
+                    "effect": "Discard 2 [P] Energy from this Pokémon."
+                }
+            ],
             "weakness": "Fighting",
             "retreat_cost": ["Colorless", "Colorless"],
             "is_ex": true
@@ -23,7 +36,14 @@
             "hp": 60,
             "energy_type": "Psychic",
             "ability": null,
-            "attacks": ["ram"],
+            "attacks": [
+                {
+                    "energy_required": ["Colorless"],
+                    "title": "Ram",
+                    "fixed_damage": 10,
+                    "effect": null
+                }
+            ],
             "weakness": "Darkness",
             "retreat_cost": ["Colorless"],
             "is_ex": false
@@ -38,7 +58,14 @@
             "hp": 80,
             "energy_type": "Psychic",
             "ability": null,
-            "attacks": ["smack"],
+            "attacks": [
+                {
+                    "energy_required": ["Colorless"],
+                    "title": "Smack",
+                    "fixed_damage": 30,
+                    "effect": null
+                }
+            ],
             "weakness": "Darkness",
             "retreat_cost": ["Colorless"],
             "is_ex": false
@@ -53,7 +80,14 @@
             "hp": 110,
             "energy_type": "Psychic",
             "ability": "PsyShadow",
-            "attacks": ["psyshot"],
+            "attacks": [
+                {
+                    "energy_required": ["Psychic", "Psychic", "Colorless"],
+                    "title": "Psyshot",
+                    "fixed_damage": 60,
+                    "effect": null
+                }
+            ],
             "weakness": "Darkness",
             "retreat_cost": ["Colorless", "Colorless"],
             "is_ex": false

--- a/pokepocketsim/data/database.json
+++ b/pokepocketsim/data/database.json
@@ -22,7 +22,7 @@
                     "effect": "Discard 2 [P] Energy from this Pokémon."
                 }
             ],
-            "weakness": "Fighting",
+            "weakness": "Darkness",
             "retreat_cost": ["Colorless", "Colorless"],
             "is_ex": true
         }
@@ -60,7 +60,7 @@
             "ability": null,
             "attacks": [
                 {
-                    "energy_required": ["Colorless"],
+                    "energy_required": ["Psychic", "Colorless"],
                     "title": "Smack",
                     "fixed_damage": 30,
                     "effect": null

--- a/pokepocketsim/engine/action_engine.py
+++ b/pokepocketsim/engine/action_engine.py
@@ -136,11 +136,19 @@ def get_available_actions(player: "Player") -> List[Action]:
 
         # ATTACK ACTIONS
         for attack in player.active_card.attacks:
+            if isinstance(attack, dict):
+                func_name = attack.get("title", "").lower().replace(" ", "_")
+                attack_callable = getattr(Attack, func_name)
+                display_name = attack.get("title", str(attack))
+            else:
+                attack_callable = attack
+                display_name = getattr(attack, "__name__", str(attack))
+
             if Attack.can_use_attack(player.active_card, attack):
                 actions.append(
                     Action(
-                        f"{player.active_card.name} use {getattr(attack, '__name__', str(attack))}",
-                        attack,
+                        f"{player.active_card.name} use {display_name}",
+                        lambda player, _atk=attack_callable: _atk(player),
                         ActionType.ATTACK,
                         can_continue_turn=False,
                     )


### PR DESCRIPTION
A huge step towards being fully compatible with the database file from deckgym. I think the only remaining field is the "is_ex" field. I originally wanted to complete this feature before creating this PR but since I'll be away the entire of next week, I'm making this PR now.

The original attacks are still in attack_common.py and should probably be cleaned-up since all the data will eventually be sourced from the database.json file.